### PR TITLE
⚡update: 오공지수 소수점 1자리만 보이게 수정

### DIFF
--- a/service/cluster.js
+++ b/service/cluster.js
@@ -103,7 +103,7 @@ async function getClusterResultResponse(result, kmeans) {
       안정성: corp.stability,       // stability
       활동성: corp.efficiency,      // activity
       생산성: corp.growth,          // potential
-      오공지수: corp.ogong_rate,    // ogoong_rate
+      오공지수: corp.ogong_rate.toFixed(1),    // ogoong_rate
     });
   }));
   return clusterResult;


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/24-plot -> dev

### 변경 사항
오공지수 소수점 1자리만 보이게 수정

### 테스트 결과
기존 소수점 6번째자리까지 보이던 오공지수가 1자리까지 보이게 되었습니다.
![image](https://github.com/oogong/backend/assets/59429729/f515283e-94cc-41e7-aa33-faebcdc21437)